### PR TITLE
Firefox project name input field fix

### DIFF
--- a/pinch/static/css/pinch.css
+++ b/pinch/static/css/pinch.css
@@ -8039,8 +8039,8 @@ form input[type="text"], form textarea.form-control {
   font-size: 21px;
 }
 /* line 221, sass/pinch.scss */
-form input[type="text"] {
-  padding: 25px 15px;
+form input[type="text"].form-control {
+  height: 50px;
 }
 /* line 224, sass/pinch.scss */
 form textarea.form-control {

--- a/pinch/static/css/sass/pinch.scss
+++ b/pinch/static/css/sass/pinch.scss
@@ -218,8 +218,8 @@ form {
 		box-shadow:none;
 		font-size:21px;
 	}
-	input[type="text"] {
-		padding:25px 15px;
+	input[type="text"].form-control {
+		height:50px;
 	}
 	textarea.form-control {
 		padding:10px 15px;


### PR DESCRIPTION
Remove padding from project name field and set specific height. Fixes an issue where text in that field in Firefox was not being displayed.
